### PR TITLE
Add "WIP" message when the url param is missing

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,10 +26,13 @@
     <link rel="stylesheet" href="/assets/css/style.css" />
   </head>
   <body>
+    <div id="work-in-progress-message">
+      <p><strong>Work in progress!</strong></p>
+      <p>We're working on finishing this website. Check back for further updates.</p>
+    </div>
+
     <div id="primary" class="container-lg px-3 my-5 markdown-body" role="main">
-
       {{ content }}
-
     </div>
   </body>
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -89,3 +89,7 @@ a {
     max-width: 100%;
   }
 }
+
+#work-in-progress-message {
+  display: none;
+}

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
   const secret = getUrlParameter('secret');
   if (secret != "hithere") {
     document.getElementById('primary').style.display = 'none';
+    document.getElementById('work-in-progress-message').style.display = 'block';
   }
 });
 


### PR DESCRIPTION
Since we've seen some folks get confused when they didn't provide the
URL parameter, let's give some kind of message that indicates that the
site is working.

<img width="557" alt="image" src="https://github.com/navapbc/FFS-IncomeReportingToolkit/assets/129120/f9190e8a-bcb5-4d45-8a28-e98308846b45">

