### PR TITLE
Use relative_url and baseurl to standardize GH pages URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: build
+.PHONY: clean build
 
+clean:
+	rm -rf _site
 build:
-	bundle exec github-pages build
+	bundle exec github-pages build --destination _site/FFS-IncomeReportingToolkit
 serve: build
+	@echo "Starting server: http://localhost:4000/FFS-IncomeReportingToolkit/?secret=hithere"
 	ruby -run -e httpd _site -p 4000

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+baseurl: "/FFS-IncomeReportingToolkit"
 defaults:
   -
     scope:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,11 +19,11 @@
     <meta name="twitter:card" content="summary" />
     <meta property="twitter:title" content="FFS-IncomeReportingToolkit" />
     <meta name="robots" content="noindex, nofollow" />
-    <script src="/assets/scripts/main.js"></script>
+    <script src="{{ "/assets/scripts/main.js" | relative_url }}"></script>
     <script type="application/ld+json">
     {"@context":"https://schema.org","@type":"WebSite","headline":"FFS-IncomeReportingToolkit","name":"FFS-IncomeReportingToolkit","url":"https://navapbc.github.io/FFS-IncomeReportingToolkit/"}</script>
 
-    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" />
   </head>
   <body>
     <div id="work-in-progress-message">


### PR DESCRIPTION
The assets were broken since locally they were generated in `/assets`
but on GitHub, it's actually under
`/FFS-IncomeVerificationToolkit/assets` due to the GH page structure.

There are a million people asking on StackOverflow about this over the
years, and the best advice seems to be to just set the "baseurl" to your
repo name and using `relative_url` to prepend the baseurl.
